### PR TITLE
Use an unambiguous format for dates.

### DIFF
--- a/lib/slack_time.js
+++ b/lib/slack_time.js
@@ -212,8 +212,8 @@ function currentUserInfo(everybody, userId) {
   }
 }
 
-function formatMonthDay(dateMoment) {
-  return dateMoment.format("MM-DD");
+function formatDayAndMonth(dateMoment) {
+  return dateMoment.format("D MMM");
 }
 
 function formatDayOfWeek(dateMoment) {
@@ -233,7 +233,7 @@ function abbreviate(string) {
 }
 
 function formatSlackDate(dateMoment) {
-  return '_' + formatDayOfWeek(dateMoment) + ' ' + formatMonthDay(dateMoment) + '_ ';
+  return '_' + formatDayOfWeek(dateMoment) + ' ' + formatDayAndMonth(dateMoment) + '_ ';
 }
 
 function formatSlackTime(dateMoment) {


### PR DESCRIPTION
Use month abbreviations instead of numeric months, since day-of-week abbreviation is already locale-dependent anyway.  Putting the day-of-month before the month abbreviation avoids the need for a comma after the day-of-week; e.g., `Mon 2 Sep` instead of `Mon, Sep 2`.

Resolves #5.