### PR TITLE
Add '/dt' slash command

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,9 +23,15 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 
 app.use('/slack/receive', slash({
-  handler: SlackTime,
+  handler: SlackTime.getSlackMessageWithChannelTimezones,
   token: process.env.SLACK_SLASH_TOKEN
 }));
+
+app.use('/slack/receive_dt', slash({
+  handler: SlackTime.getSlackMessageWithLocalTime,
+  token: process.env.SLACK_SLASH_TOKEN
+}));
+
 app.use('/slack', auth({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,

--- a/lib/slack_time.js
+++ b/lib/slack_time.js
@@ -12,7 +12,9 @@ var logger = require('../lib/logger');
 var NodeCache = require('node-cache');
 var unknownRecipientMessageCache = new NodeCache();
 
-module.exports = SlackTime = function (args) {
+module.exports = SlackTime = {};
+
+SlackTime.getSlackMessageWithChannelTimezones = function (args) {
   var token = args.apiToken;
   var originalMessage = args.message;
   var currentUserId = args.currentUserId;
@@ -64,7 +66,25 @@ module.exports = SlackTime = function (args) {
     var message = addTimezonesToSlackMessage(originalMessage, userInfo, zones);
     return postToSlack(channelId, userInfo, message, token);
   });
-}
+};
+
+SlackTime.getSlackMessageWithLocalTime = function (args) {
+  var token = args.apiToken;
+  var originalMessage = args.message;
+  var currentUserId = args.currentUserId;
+  var teamId = args.teamId;
+  var channelId = args.channelId;
+
+  return getUserList(token)
+  .then(parseUserList)
+  .then(function (userList) {
+    var userInfo = currentUserInfo(userList.members, currentUserId);
+
+    var message = addLocalTimeToSlackMessage(originalMessage, userInfo);
+
+    return postToSlack(channelId, userInfo, message, token);
+  });
+};
 
 SlackTime.requiredOAuthScopes = "users:read,chat:write:bot,channels:read,commands";
 
@@ -121,7 +141,7 @@ function updateChannelAndProcessOriginalMessage(args) {
   .then(function () {
     var originalMessage = unknownRecipientMessageCache.get(teamId + "|" + channelId);
     args.message = originalMessage;
-    return SlackTime(args);
+    return SlackTime.getSlackMessageWithChannelTimezones(args);
   });
 }
 
@@ -268,6 +288,23 @@ function formatChannelLocalTimes(startMoment, endMoment, userInfo, zones) {
   return times.join(", ");
 }
 
+function toSlackFormattedDate(unix, timeOnly) {
+  timeOnly = timeOnly || false;
+
+  return '<!date^' + unix + '^' + (timeOnly ? '{time}':'{date_short_pretty} {time}') + '|Unix:' + unix + '>';
+}
+
+function formatUserLocalTimes(startMoment, endMoment) {
+  var dateStartString = formatSlackDate(startMoment);
+  var startUnix = startMoment.unix();
+
+  var includeEndDate = endMoment && formatSlackDate(endMoment) !== dateStartString;
+
+  var formatted = toSlackFormattedDate(startUnix) + (endMoment ? ' to ' + toSlackFormattedDate(endMoment.unix(), !includeEndDate) : '');
+
+  return formatted;
+}
+
 function chronoResultToUtcMoment(result, userInfo) {
   if (!result) {
     return;
@@ -279,6 +316,14 @@ function chronoResultToUtcMoment(result, userInfo) {
     dateMoment.add(-userInfo.timezoneOffset, 'minutes');
   }
   return dateMoment;
+}
+
+function chronoResultToMoment(result) {
+  if (!result) {
+    return;
+  }
+
+  return result.moment();
 }
 
 function addTimezonesToSlackMessage(message, userInfo, zones) {
@@ -294,6 +339,20 @@ function addTimezonesToSlackMessage(message, userInfo, zones) {
 
   return message;
 }
+
+function addLocalTimeToSlackMessage(message, userInfo) {
+
+  var ref = moment().add(-moment().utcOffset() + userInfo.timezoneOffset, 'minutes');
+  var results = chrono.parse(message, ref);
+
+  results.forEach(function(result) {
+    var userLocalTime = formatUserLocalTimes(chronoResultToMoment(result.start), chronoResultToMoment(result.end));
+    message = message.replace(result.text, result.text + ' (' + userLocalTime + ' _at your local time_)');
+  });
+
+  return message;
+}
+
 
 function sortObjectToArray(obj) {
   out = [];


### PR DESCRIPTION
### PR Description

This PR introduces an additional slash command that will automatically parse a message to convert the time to the viewing member's local time.
This removes the need for an extra question to list channel members in private channels improving the UX in private channel and direct messages.
Furthermore, it improves the UX in cases where we simply want to display a date to everyone viewing that text in their current local time without mentioning all other team members' timezones.

### Added functionality

- Adds a new slash command, `/dt`
- Adds a new endpoint, `slash/receive-dt` that receives the POST payload from the `dt` slash command
- Makes use of Slack's [Date Formatting ](https://api.slack.com/reference/surfaces/formatting#date-formatting) in order to display a date in the local timezone of the person seeing the text.

### Sample

![Screen Capture on 2020-06-22 at 01-31-09](https://user-images.githubusercontent.com/1758399/85236728-1956d000-b429-11ea-9b2b-541a82275a26.gif)
